### PR TITLE
Modified entrypoint.sh and Dockerfile to fix pacman user issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base:latest
+FROM archlinux:base
 
 RUN pacman -Syu --needed --noconfirm \
     binutils \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,11 +4,12 @@ if [ -d "/github" ]; then
 sudo chown -R build /github/workspace /github/home
 fi
 
-pacman -Sy
+sudo pacman -Sy
+export MAKEFLAGS=-j$(nproc)
 namcap PKGBUILD
 makepkg -fC --syncdeps --noconfirm
 
 echo "==============="
 echo "Package created:"
-echo `ls *.pkg.tar.xz`
+echo `ls *.pkg.tar.zst`
 echo "==============="


### PR DESCRIPTION
There was an issue that "pacman -Sy" command in entrypoint.sh does not work because it ran with user build, resulting in problem when syncing dependencies with makepkg (404 error because of old db). I fixed this issue by adding sudo to the command.
I also modified base image tag so when an image is built docker can pull correct image 
and added support for multicore (Github Actions seems to have about 2 cores; not sure) to GNU make by exporting MAKEFLAGS="-j$(nproc)"

Sorry for my poor english or any mistakes.